### PR TITLE
feat: npx support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
   "bin": {
-    "rss": "build/src/cli.js"
+    "rss": "build/src/cli.js",
+    "require-so-slow":"build/src/cli.js"
   },
   "dependencies": {
     "npm-package-arg": "^6.1.0",


### PR DESCRIPTION
add bin script named after the module so folks can `npx require-so-slow request` instead of `npx -p require-so-slow rss request`
also it doesn't seem like the cli bin has been published as part of any version