### PR TITLE
chore: drop support for node.js 4.x and 9.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,47 +7,32 @@ release_tags: &release_tags
 unit_tests: &unit_tests
   steps:
     - checkout
-    - run:
-        name: Install modules and dependencies.
-        command: npm install
-    - run:
-        name: Run unit tests.
-        command: npm test
-    - run:
-        name: Submit coverage data to codecov.
-        command: npm run codecov
-        when: always
+    - run: npm install
+    - run: npm test
+    - run: npm run codecov
 
 version: 2.0
 workflows:
   version: 2
   tests:
     jobs:
-      - node4:
-          filters: *release_tags
       - node6:
           filters: *release_tags
       - node8:
           filters: *release_tags
-      - node9:
+      - node10:
           filters: *release_tags
       - publish_npm:
           requires:
-            - node4
             - node6
             - node8
-            - node9
+            - node10
           filters:
             branches:
               ignore: /.*/
             <<: *release_tags
 
 jobs:
-  node4:
-    docker:
-      - image: node:4
-        user: node
-    <<: *unit_tests
   node6:
     docker:
       - image: node:6
@@ -58,7 +43,7 @@ jobs:
       - image: node:8
         user: node
     <<: *unit_tests
-  node9:
+  node10:
     docker:
       - image: node:9
         user: node
@@ -70,12 +55,6 @@ jobs:
         user: node
     steps:
       - checkout
-      - run:
-          name: Set NPM authentication.
-          command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
-      - run:
-          name: Install modules and dependencies.
-          command: npm install
-      - run:
-          name: Publish the module to npm.
-          command: npm publish
+      - run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+      - run: npm install
+      - run: npm publish

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "require-so-slow",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "types": "build/src/index.d.ts",
   "bin": {
     "rss": "build/src/cli.js",
-    "require-so-slow":"build/src/cli.js"
+    "require-so-slow": "build/src/cli.js"
   },
   "dependencies": {
     "npm-package-arg": "^6.1.0",
@@ -24,6 +24,9 @@
     "source-map-support": "^0.5.6",
     "tape": "^4.9.1",
     "typescript": "~2.9.1"
+  },
+  "engines": {
+    "node": ">=6"
   },
   "scripts": {
     "test": "nyc tape -r source-map-support/register build/test/test*.js",


### PR DESCRIPTION
BREAKING CHANGE: This removes support for node.js 4.x and 9.x. It may work, but it will no longer be tested. 