### PR TITLE
build!: drop support for Node 6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,8 +16,6 @@ workflows:
   version: 2
   tests:
     jobs:
-      - node6:
-          filters: *release_tags
       - node8:
           filters: *release_tags
       - node10:
@@ -26,7 +24,6 @@ workflows:
           filters: *release_tags
       - publish_npm:
           requires:
-            - node6
             - node8
             - node10
             - node11
@@ -36,11 +33,6 @@ workflows:
             <<: *release_tags
 
 jobs:
-  node6:
-    docker:
-      - image: node:6
-        user: node
-    <<: *unit_tests
   node8:
     docker:
       - image: node:8

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "typescript": "~3.4.0"
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "scripts": {
     "test": "nyc tape -r source-map-support/register build/test/test*.js",


### PR DESCRIPTION
BREAKING CHANGE: Node.js is reaching EOL. Stop supporting it.